### PR TITLE
Speed up clutter and improve run.sh

### DIFF
--- a/haskell/BufwiseClutter/BufwiseClutter.hs
+++ b/haskell/BufwiseClutter/BufwiseClutter.hs
@@ -20,7 +20,7 @@ import qualified TextCounter as C
 
 main :: IO ()
 main = do
-  t <- C.new 60000
+  t <- C.new 48000 16000
   let incr = C.count t
   flip fix T.empty $ \rec b -> do
     bs <- T.hGetChunk stdin -- (64 * 1024)
@@ -31,7 +31,7 @@ main = do
         (initial, last) <-
               T.spanEndM (pure . not . isSpace)
                 . mappend b
-                . T.map toLower
+                . T.toLower
                 $ bs
         mapM_ incr (T.words initial)
         rec last

--- a/haskell/LinewiseClutter/LinewiseClutter.hs
+++ b/haskell/LinewiseClutter/LinewiseClutter.hs
@@ -20,9 +20,9 @@ unlessM m1 m2 = m1 >>= \b -> unless b m2
 
 main :: IO ()
 main = do
-  t <- C.new 60000
+  t <- C.new 48000 16000
   let go = unlessM isEOF $ do
-        wrds <- T.words .  T.map toLower <$> T.getLine
+        wrds <- T.words .  T.toLower <$> T.getLine
         traverse_ (C.count t) wrds
         go
   go

--- a/haskell/run.sh
+++ b/haskell/run.sh
@@ -6,10 +6,12 @@ stack --bash-completion-index 2 --bash-completion-word stack --bash-completion-w
     | while read -r cexe; do
     exe=${cexe##countwordsHS:exe:}
     if command -V nix &>/dev/null; then
-        nix run nixpkgs.hyperfine -c hyperfine \
-            "stack exec \"$exe\" -- < ../kjvbible_x10.txt"
+        nix run nixpkgs.hyperfine -c stack exec hyperfine -- \
+            --warmup 1 "\"$exe\" <../kjvbible_x10.txt"
+    elif command -V hyperfine &>/dev/null; then
+      stack exec hyperfine -- --warmup 1 "\"$exe\" <../kjvbible_x10.txt"
     else
-        time stack exec "$exe" -- < ../kjvbible_x10.txt >/dev/null
-        echo "↑ $exe ↑"
+      echo "$exe:"
+      stack exec /usr/bin/env -- time "$exe" <../kjvbible_x10.txt >/dev/null
     fi
 done

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -46,9 +46,10 @@ extra-deps:
 - streamly-0.8.1.1
 - vector-hashtables-0.1.1.1@sha256:cb4ba4af6b83b6956278bbfe8d0f779a40928728e82977e566c0103fe8d6c867,2725
 - git: https://github.com/noughtmare/clutter.git
-  commit: 5407a948fbcde4a27443ffb6cadb61c78c6d1f0a
+  commit: 1e2e7e2dbf71f24f2511aded66ee24a6bd3cef5d
 - compact-0.2.0.0@sha256:75ef98cb51201b4a0d6de95cbbb62be6237c092a3d594737346c70c5d56c2380,2413
-- text-2.0.1
+- git: https://github.com/haskell/text.git
+  commit: 8ae2888a340911e088ad9507f22464dc383c944b
 - text-short-0.1.5
 - hashable-1.4.0.2
 - git: https://github.com/serokell/haskell-with-utf8.git


### PR DESCRIPTION
This commit changes a few things:

* Use a newer commit of clutter for some extra optimizations
* Use the newer commit of text for the toLower optimization
* Run `stack exec hyperfine ...` instead of `hyperfine "stack exec ..."`, so this now no longer counts the time that stack takes to start your program
* Add an option for when nix is not installed, but hyperfine is (like on my machine)

Results on my machine:

```
Benchmark 1: "BufwiseClutter" <../kjvbible_x10.txt
  Time (mean ± σ):     584.3 ms ±   5.2 ms    [User: 553.9 ms, System: 21.7 ms]
  Range (min … max):   573.3 ms … 590.9 ms    10 runs
 
Benchmark 1: "BufwiseVHBS" <../kjvbible_x10.txt
  Time (mean ± σ):      1.007 s ±  0.010 s    [User: 0.979 s, System: 0.021 s]
  Range (min … max):    0.993 s …  1.023 s    10 runs
 
Benchmark 1: "LazyHMBS" <../kjvbible_x10.txt
  Time (mean ± σ):      4.138 s ±  0.040 s    [User: 3.742 s, System: 0.389 s]
  Range (min … max):    4.097 s …  4.235 s    10 runs
 
Benchmark 1: "LazyHMRef" <../kjvbible_x10.txt
  Time (mean ± σ):      2.323 s ±  0.017 s    [User: 2.237 s, System: 0.079 s]
  Range (min … max):    2.300 s …  2.350 s    10 runs
 
Benchmark 1: "LazyMap" <../kjvbible_x10.txt
  Time (mean ± σ):      4.763 s ±  0.029 s    [User: 4.669 s, System: 0.085 s]
  Range (min … max):    4.735 s …  4.840 s    10 runs
 
Benchmark 1: "LazyVH" <../kjvbible_x10.txt
  Time (mean ± σ):      1.969 s ±  0.013 s    [User: 1.894 s, System: 0.069 s]
  Range (min … max):    1.951 s …  1.986 s    10 runs
 
Benchmark 1: "LinewiseClutter" <../kjvbible_x10.txt
  Time (mean ± σ):     760.7 ms ±   9.1 ms    [User: 727.0 ms, System: 23.9 ms]
  Range (min … max):   746.2 ms … 780.7 ms    10 runs
 
Benchmark 1: "LinewiseVH" <../kjvbible_x10.txt
  Time (mean ± σ):      2.014 s ±  0.018 s    [User: 1.975 s, System: 0.029 s]
  Range (min … max):    1.991 s …  2.045 s    10 runs
 
Benchmark 1: "StreamingHMBS" <../kjvbible_x10.txt
  Time (mean ± σ):      4.714 s ±  0.093 s    [User: 4.666 s, System: 0.040 s]
  Range (min … max):    4.625 s …  4.883 s    10 runs
 
Benchmark 1: "StreamlyHMRef" <../kjvbible_x10.txt
  Time (mean ± σ):      2.096 s ±  0.053 s    [User: 2.065 s, System: 0.022 s]
  Range (min … max):    2.022 s …  2.191 s    10 runs
 
Benchmark 1: "StreamlyThreadedHMRef" <../kjvbible_x10.txt
  Time (mean ± σ):      3.115 s ±  0.019 s    [User: 8.371 s, System: 1.583 s]
  Range (min … max):    3.079 s …  3.145 s    10 runs
 
Benchmark 1: "StreamlyVH" <../kjvbible_x10.txt
  Time (mean ± σ):      1.875 s ±  0.014 s    [User: 1.846 s, System: 0.021 s]
  Range (min … max):    1.854 s …  1.905 s    10 runs
```