### PR TITLE
Use newer version of clutter with critical bug fix

### DIFF
--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -46,7 +46,7 @@ extra-deps:
 - streamly-0.8.1.1
 - vector-hashtables-0.1.1.1@sha256:cb4ba4af6b83b6956278bbfe8d0f779a40928728e82977e566c0103fe8d6c867,2725
 - git: https://github.com/noughtmare/clutter.git
-  commit: 1e2e7e2dbf71f24f2511aded66ee24a6bd3cef5d
+  commit: c1746fe8e208964e7b53c447d8f32a89908afbb7
 - compact-0.2.0.0@sha256:75ef98cb51201b4a0d6de95cbbb62be6237c092a3d594737346c70c5d56c2380,2413
 - git: https://github.com/haskell/text.git
   commit: 8ae2888a340911e088ad9507f22464dc383c944b


### PR DESCRIPTION
Turns out that there was a bug that made my code quite a bit faster than it should be. Basically it would map most short words to the same hash table entry.